### PR TITLE
Throw regular Error objects instead of enums

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,5 @@
 /// <reference path="node.d.ts" />
-/**
- * Rust-inspired Result<T, E> and Option<T> (called Maybe) wrappers for Javascript.
- *
- * @author mystor
- * @author uniphil
- */
-/**
- * @throws EnumError.NonExhaustiveMatch
- */
+declare var $: any;
 declare function match(to: any): any;
 interface EnumOption {
     options: any;
@@ -18,32 +10,15 @@ interface EnumOption {
 }
 declare function _factory(options: Object, name: string, EnumOptionClass: EnumOption): (...args: any[]) => EnumOption;
 declare function Enum<T>(options: T, proto?: any, factory?: any): T;
-declare var $: any;
-declare var EnumErr: {
-    BadOptionType: any;
-    NonExhaustiveMatch: any;
-};
-declare var MaybeError: {
-    UnwrapNone: any;
-};
 interface Maybe {
     Some: (someValue) => EnumOption;
     None: () => EnumOption;
 }
 interface MaybeOption {
-    /**
-     * @throws EnumError.NonExhaustiveMatch
-     */
     match: (opts: Object) => any;
     isSome: () => Boolean;
     isNone: () => Boolean;
-    /**
-     * @throws whatever is passed as the arg
-     */
     expect: (err) => any;
-    /**
-     * @throws MaybeError.UnwrapNone
-     */
     unwrap: () => any;
     unwrapOr: (def) => any;
     unwrapOrElse: (fn: () => any) => any;
@@ -73,9 +48,6 @@ interface Result {
     Err: (errValue) => EnumOption;
 }
 interface ResultOption {
-    /**
-     * @throws EnumError.NonExhaustiveMatch
-     */
     match: (opts: Object) => any;
     isOk: () => Boolean;
     isErr: () => Boolean;
@@ -90,13 +62,7 @@ interface ResultOption {
     orElse: (fn: (errValue) => Result) => Result;
     unwrapOr: (def: any) => any;
     unwrapOrElse: (fn: (errValue) => any) => any;
-    /**
-     * @throws the value from Err(value)
-     */
     unwrap: () => any;
-    /**
-     * @throws the value from Ok(value)
-     */
     unwrapErr: () => any;
 }
 declare var resultProto: ResultOption;

--- a/index.ts
+++ b/index.ts
@@ -7,8 +7,12 @@
 
 /// <reference path="./node.d.ts" />
 
+
+var $;  // just a  placeholder for RHS of objects whose keys we want
+
+
 /**
- * @throws EnumError.NonExhaustiveMatch
+ * @throws Error if the match is not exhaustive
  */
 function match(to: any): any {
   if (typeof to._ === 'function') {  // match is de-facto exhaustive w/ `_`
@@ -21,7 +25,7 @@ function match(to: any): any {
     // ensure match is exhaustive
     for (let k in this.options) {
       if (typeof to[k] !== 'function') {
-        throw EnumErr.NonExhaustiveMatch(k);
+        throw new Error(`Enum match: Non-exhaustive match is missing '${k}'`);
       }
     }
     return to[this.name].apply(null, this.data);
@@ -52,7 +56,6 @@ function _factory(options: Object, name: string, EnumOptionClass: EnumOption):
 
 
 function Enum<T>(options: T, proto:any={}, factory:any=_factory): T {
-  if (typeof options !== 'object') { throw EnumErr.BadOptionType(); }
   function EnumOption(options: T, name: string, data: any[]) {
     this.options = options;
     this.name = name;
@@ -69,18 +72,6 @@ function Enum<T>(options: T, proto:any={}, factory:any=_factory): T {
 }
 
 
-var $;
-var EnumErr = Enum({
-  BadOptionType:      $,
-  NonExhaustiveMatch: $,
-});
-
-
-var MaybeError = Enum({
-  UnwrapNone: $,
-});
-
-
 interface Maybe {
   Some: (someValue) => EnumOption;
   None: () => EnumOption;
@@ -88,7 +79,7 @@ interface Maybe {
 
 interface MaybeOption {
   /**
-   * @throws EnumError.NonExhaustiveMatch
+   * @throws Error if the match is not exhaustive
    */
   match: (opts: Object) => any;
   isSome: () => Boolean;
@@ -98,7 +89,7 @@ interface MaybeOption {
    */
   expect: (err) => any;
   /**
-   * @throws MaybeError.UnwrapNone
+   * @throws Error if it is None
    */
   unwrap: () => any;
   unwrapOr: (def) => any;
@@ -141,7 +132,7 @@ var maybeProto: MaybeOption = {
     if (this.name === 'Some') {
       return this.data;
     } else {
-      throw MaybeError.UnwrapNone('Tried to unwrap None');
+      throw new Error('Maybe Enum: Tried to .unwrap() None as Some');
     }
   },
   unwrapOr(def) {
@@ -214,7 +205,7 @@ interface Result {
 
 interface ResultOption {
   /**
-   * @throws EnumError.NonExhaustiveMatch
+   * @throws Error if the match is not exhaustive
    */
   match: (opts: Object) => any;
   isOk: () => Boolean;

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,8 @@ Todo for v1.0.0:
     completion, and also enables some opt-in construction optimizations and
     typechecking.
   * Enum option instance property `options` is now an Object instead of Array.
+  * Throw `Error` instances instead of special internal error enums. It was a silly idea.
+  * Remove sketchy faulty object typecheck for the Enum constructor. It's just not checked now. Whee.
 
 #### Other Changes
 

--- a/test.js
+++ b/test.js
@@ -4,43 +4,14 @@ var {Enum, Ok, Err, Some, None} = require('./index');
 
 describe('Enum', () => {
   it('should fail if options are missing', () => {
-    var answer;
-    try {
-      Enum();
-    } catch(err) {
-      answer = err.match({
-        BadOptionType: () => 'the right answer',
-        _: (what) => 'the wrong answer: ' + what,
-      });
-    }
-    assert.equal(answer, 'the right answer');
-  });
-  it('should fail for bad option type', () => {
-    var answer;
-    try {
-      Enum('abc');
-    } catch(err) {
-      answer = err.match({
-        BadOptionType: () => 'the right answer',
-        _: (what) => 'the wrong answer: ' + what,
-      });
-    }
-    assert.equal(answer, 'the right answer');
+    assert.throws(() => Enum(), Error);
   });
   it('should accept an object', () => {
     assert.equal(Enum({A: null}).A().match({A: () => 42}), 42);
   });
   it('should ensure that the match paths are exhaustive', () => {
-    var answer;
-    try {
-      Enum({A: 0, B: 0}).A().match({A: () => 'whatever'});
-    } catch(err) {
-      answer = err.match({
-        NonExhaustiveMatch: () => 'the right answer',
-        _: () => 'the wrong answer',
-      });
-    }
-    assert.equal(answer, 'the right answer');
+    var myEnum = Enum({A: 0, B: 0}).A();
+    assert.throws(() => myEnum.match({a: () => 'whatever'}), Error);
   });
   it('should always be exhaustive with a wildcard match', () => {
     assert.equal(Enum({A: 0, B: 0}).A().match({_: () => 42}), 42);
@@ -78,17 +49,7 @@ describe('Maybe', () => {
   });
   it('should unwrap or throw', () => {
     assert.equal(Some(1).unwrap(), 1);
-    assert.throws(() => {None().unwrap()});
-    var answer;
-    try {
-      None().unwrap();
-    } catch (err) {
-      answer = err.match({
-        UnwrapNone: () => 'the right answer',
-        _: (what) => 'the wrong answer: ' + what,
-      });
-      assert.equal(answer, 'the right answer');
-    }
+    assert.throws(() => None().unwrap(), Error);
   });
   it('should unwrap its value or a default for unwrapOr', () => {
     assert.equal(Some(1).unwrapOr(2), 1);


### PR DESCRIPTION
It was a silly idea, intended to make `catch (err) {` nicer because you could `.match()` on `err`.

However, this makes no sense, because consumers of things using `results` should see only regular JS behaviour.
Also, logging an `Err()` isn't that nice (separate issue, but maybe .toString can help).

It also makes no sense because a primary motivation to use this library is getting away from exception-oriented
error-handling. So lets not insert ourselves back into that awful world. Just throw regular errors.
