### PR TITLE
Catch-all key (_) as a symbol

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -5,23 +5,23 @@
  * @author uniphil
  */
 
+ const _ = Symbol('Union match catch-all symbol');
+
 
 /**
  * @throws Error if the match is not exhaustive, or if there are weird keys
  */
 function match(to) {
-  for (let k in to) {
-    if (to.hasOwnProperty(k)) {
-      if (!this.options.hasOwnProperty(k) && k !== '_') {
-        throw new Error(`Union match: unrecognized match option: '${k}'`);
-      }
+  for (let k of Object.keys(to)) {
+    if (!this.options.hasOwnProperty(k) && k !== _) {
+      throw new Error(`Union match: unrecognized match option: '${k}'`);
     }
   }
-  if (typeof to._ === 'function') {  // match is de-facto exhaustive w/ `_`
+  if (typeof to[_] === 'function') {  // match is de-facto exhaustive w/ `_`
     if (typeof to[this.name] === 'function') {
       return to[this.name].apply(null, this.data);
     } else {
-      return to._(this);
+      return to[_](this);
     }
   } else {
     // ensure match is exhaustive
@@ -292,6 +292,7 @@ const Result = Union({
 
 module.exports = {
   Union,
+  _,
 
   Maybe,
   Some: Maybe.Some,

--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,13 @@ _in progress_
     longer be used as a key in Unions.
   * The typescript declaration file is removed. It could be re-created and added
     to definitelyTyped or something, if anyone wants it.
+  * **Match's _ special-case catch-all key is removed**. Instead, `results` now
+    exports a symbol as `_` that you can use as a computed key like
+      ```js
+      Union({A: {}, B: {}, C: {}}).A().match({
+        A: () => console.log('A!'),
+        [_]: () => console.log('something else...'),
+      });
 
 ### Other Changes
 


### PR DESCRIPTION
Could consider renaming it `default` instead of `_`:

``` js
something.match({
  first: () => 1,
  [default]: () => Infinity,
})
```

``` js
something.match({
  first: () => 1,
  [_]: () => Infinity,
})
```

...actually, `default` being a keyword, probably wouldn't work. `_` for now.
