### PR TITLE
Result.Ok() and Maybe.Some() promote instead of transform

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -95,13 +95,6 @@ function Union(options, proto={}, static_={}, factory=_factory) {
 
 
 const maybeProto = {
-  _promote(value) {
-    if (value instanceof Maybe.OptionClass) {
-      return value;
-    } else {
-      return Maybe.Some(value);
-    }
-  },
   isSome() {
     return this.name === 'Some';
   },
@@ -147,16 +140,16 @@ const maybeProto = {
     return (this.name === 'Some') ? Promise.resolve(this.data) : Promise.reject(fn());
   },
   and(other) {
-    return (this.name === 'Some') ? this._promote(other) : this;
+    return (this.name === 'Some') ? Maybe.Some(other) : this;
   },
   andThen(fn) {
-    return (this.name === 'Some') ? this._promote(fn(this.data)) : this;
+    return (this.name === 'Some') ? Maybe.Some(fn(this.data)) : this;
   },
   or(other) {
-    return (this.name === 'Some') ? this : this._promote(other);
+    return (this.name === 'Some') ? this : Maybe.Some(other);
   },
   orElse(fn) {
-    return (this.name === 'Some') ? this : this._promote(fn());
+    return (this.name === 'Some') ? this : Maybe.Some(fn());
   },
 };
 
@@ -167,8 +160,8 @@ const maybeStatic = {
     return match.call(this, normalOption, paths);
   },
   all: (values) => values.reduce((res, next) =>
-    res.andThen(resArr => maybeProto._promote(next)
-      .andThen(v => Maybe.Some(resArr.concat(v))))
+    res.andThen(resArr => Maybe.Some(next)
+      .andThen(v => resArr.concat(v)))
   , Maybe.Some([])),
 };
 
@@ -192,13 +185,6 @@ const Maybe = Union({
 
 
 const resultProto = {
-  _promote(value) {
-    if (value instanceof Result.OptionClass) {
-      return value;
-    } else {
-      return Result.Ok(value);
-    }
-  },
   isOk() {
     return this.name === 'Ok';
   },
@@ -218,16 +204,16 @@ const resultProto = {
     return (this.name === 'Ok') ? Promise.reject(this.data) : Promise.resolve(this.data);
   },
   and(other) {
-    return (this.name === 'Ok') ? this._promote(other) : this;
+    return (this.name === 'Ok') ? Result.Ok(other) : this;
   },
   andThen(fn) {
-    return (this.name === 'Ok') ? this._promote(fn(this.data)) : this;
+    return (this.name === 'Ok') ? Result.Ok(fn(this.data)) : this;
   },
   or(other) {
-    return (this.name === 'Ok') ? this : this._promote(other);
+    return (this.name === 'Ok') ? this : Result.Ok(other);
   },
   orElse(fn) {
-    return (this.name === 'Ok') ? this : this._promote(fn(this.data));
+    return (this.name === 'Ok') ? this : Result.Ok(fn(this.data));
   },
   unwrapOr(def) {
     return (this.name === 'Ok') ? this.data : def;
@@ -264,8 +250,8 @@ const resultStatic = {
     return match.call(this, normalOption, paths);
   },
   all: (values) => values.reduce((res, next) =>
-    res.andThen(resArr => resultProto._promote(next)
-      .andThen(v => Result.Ok(resArr.concat(v))))
+    res.andThen(resArr => Result.Ok(next)
+      .andThen(v => resArr.concat(v)))
   , Result.Ok([])),
 };
 

--- a/index.es6
+++ b/index.es6
@@ -180,8 +180,7 @@ const Maybe = Union({
   if (name === 'Some') {
     return (value) => {
       if (value instanceof UnionOptionClass) {
-        const unwrapped = value.unwrapOr();  // Some's value or Undefined
-        return new UnionOptionClass(options, 'Some', unwrapped);
+        return value;
       } else {
         return new UnionOptionClass(options, 'Some', value);
       }
@@ -277,8 +276,7 @@ const Result = Union({
   if (name === 'Ok') {
     return (value) => {
       if (value instanceof UnionOptionClass) {
-        const unwrapped = value.unwrapOrElse(e => e);
-        return new UnionOptionClass(options, 'Ok', unwrapped);
+        return value;
       } else {
         return new UnionOptionClass(options, 'Ok', value);
       }

--- a/readme.md
+++ b/readme.md
@@ -328,7 +328,8 @@ An optional type.
 
 Also exported as `Some` from Results (`import { Some } from 'results';`).
 
-- **`payload`** A single parameter of any type.
+- **`payload`** A single parameter of any type. If it is an instance of
+  `Maybe.OptionClass`, it will just be returned.
 
 #### `Maybe.None()`
 
@@ -467,7 +468,8 @@ An error-handling type.
 
 Also exported as `Ok` from Results (`import { Ok } from 'results';`).
 
-- **`payload`** A single parameter of any type.
+- **`payload`** A single parameter of any type. If it is an instance of
+  `Result.OptionClass`, it will simply be returned.
 
 #### `Result.Err(err)`
 
@@ -602,6 +604,18 @@ The APIs for `Maybe`, and `Result` are _heavily_ influenced by
 
 Changes
 -------
+
+### v0.9.0
+
+#### Breaking
+
+  * **Result.Ok(value)** now **returns** `value` if it is an instance of
+    `Result.OptionClass`, instead of unwrapping and rewrapping as `Ok`, and
+  * **Maybe.Some(value)** now **returns** `value` if it's a `Maybe.OptionClass`,
+    instead of unwrapping and rewrapping as `Some`. These changes are included
+    to provide a way to "cast" arbitrary values to Result or Maybe, mirroring
+    `Promise.resolve(value)`.
+
 
 ### v0.8.0
 

--- a/test.js
+++ b/test.js
@@ -81,9 +81,9 @@ describe('Maybe', () => {
     assert.equal(Some(1).isNone(), false);
     assert.equal(None().isSome(), false);
   });
-  it('.Some should unwrap Maybes given to it', () => {
+  it('.Some should use Maybes given to it', () => {
     assert.equal(Some(Some(1)).unwrap(), 1);
-    assert.equal(Some(None()).unwrap(), undefined);
+    assert.equal(Some(None()).isNone(), true);
   });
   it('should throw or not for expect', () => {
     assert.doesNotThrow(() => {Some(1).expect('err')});
@@ -221,9 +221,9 @@ describe('Result', () => {
     assert.equal(Ok(1).isErr(), false);
     assert.equal(Err(2).isOk(), false);
   });
-  it('.Ok should unwrap Results given to it', () => {
+  it('.Ok should use a Result given to it', () => {
     assert.equal(Ok(Ok(1)).unwrap(), 1);
-    assert.equal(Ok(Err(2)).unwrap(), 2);
+    assert.equal(Ok(Err(2)).isErr(), true);
   });
   it('.Err should not unwrap Results given to it', () => {
     assert.ok(Err(Ok(1)).unwrapErr().isOk());


### PR DESCRIPTION
Those functions return their argument if the argument is already an `Err` or `Ok`, or `None`  or `Some`, respectively.

This brings the API closer to `Promise`, specifically `Promise.resolve()`.
