### PR TITLE
Revert _ to a literal/string instead of symbol

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -21,15 +21,16 @@ function match(option, paths) {
     throw new Error(`Union match: called on a non-member option: '${option}'`);
   }
   for (let k of Object.keys(paths)) {
-    if (!option.options.hasOwnProperty(k) && k !== _) {
+    if (!option.options.hasOwnProperty(k) && k !== '_' && k !== _) {  // DEPRECATED symbol _
       throw new Error(`Union match: unrecognized match option: '${k}'`);
     }
   }
-  if (typeof paths[_] === 'function') {  // match is de-facto exhaustive w/ `_`
+  // DEPRECATED: symbol [_] catch-all will be removed after 0.10
+  if (typeof paths._ === 'function' || typeof paths[_] === 'function') {  // match is de-facto exhaustive w/ `_`
     if (typeof paths[option.name] === 'function') {
       return paths[option.name](...option.data);
     } else {
-      return paths[_](option);
+      return (paths._ || paths[_])(option);  // DEPRECATED symbol [_]
     }
   } else {
     // ensure match is exhaustive
@@ -288,7 +289,7 @@ const Result = Union({
 
 module.exports = {
   Union,
-  _,
+  _,  // DEPRECATED
 
   Maybe,
   Some: Maybe.Some,

--- a/index.es6
+++ b/index.es6
@@ -77,6 +77,9 @@ function Union(options, proto={}, static_={}, factory=_factory) {
         `has the same name as a member (members: ${options.join(', ')}).`);
     }
   }
+  if (options.hasOwnProperty('_')) {  // DEPRECATED
+    console.warn('DEPRECATION WARNING: The union member name "_" will be reserved and throw an error in the next version of Results.');
+  }
   function UnionOption(options, name, data) {
     this.options = options;
     this.name = name;

--- a/readme.md
+++ b/readme.md
@@ -217,7 +217,7 @@ Returns a `union` object.
   want to get down and dirty.
 
 
-#### `Union._` the catch-all symbol
+#### `Union._` the catch-all symbol (DEPRECATED)
 
 A reference to a symbol you can import and use as a computed property
 (`{[computedProp]: val}`) in a `match` to handle any unmatched paths.
@@ -225,6 +225,9 @@ A reference to a symbol you can import and use as a computed property
 Since `Union._` is a symbol, you technically _can_ also have `'_'` as a member
 of a union. But please don't :)
 
+_this symbol is deprecated, and will be gone in the next release after 0.10.
+To wild-card match, just use a normal string key _ instead of the symbol. _ is
+now back to a reserved match member name._
 
 ```js
 import { Union, _ } from 'results';
@@ -265,8 +268,12 @@ control program flow depending on which member of Union you are dealing with.
 - **`paths`** an object, mapping member names to callback functions. The object
   must _either_ exhaustively cover all members in the Union with callbacks, _or_
   map zero or more members to callbacks and provide a catch-all callback for the
-  symbol `_`, exported by Results. If the coverage is not exhaustive, or if
-  unrecognized names are included as keys, `.match` will throw.
+  name `'_'`. If the coverage is not exhaustive, or if unrecognized names are
+  included as keys, `.match` will throw.
+
+  DEPRECATED: Results exports a symbol `_` that can be used as a computed
+  property `[_]` in match for catch-all matching. This will be gone in the next
+  version.
 
 `.match` will synchronously call the matching callback and return its result,
 passing params to the callback as follows:
@@ -626,6 +633,20 @@ Changes
 
   * Added static methods `Result.try`, `Maybe.undefined`, and `Maybe.null` for
     plain-js interop. See the docs for details.
+
+#### Breaking changes
+
+  * Deprecating the `_` symbol has a breaking edge-case: A match from a union
+    containing a member called `"_"` that _also_ has a wild-card member `[_]`
+    (the symbol), will always take the `"_"` path instead of the catch-all
+    symbol path. I'm fairly confident this affects zero people.
+
+#### Deprecations
+
+  * The symbol exported from results as `_` is now deprecated. To do a catch-all
+    match, just use a normal `'_'` string key. For a cost of having one more
+    reserved member name (never ever used?), catch-all matching (frequently
+    used) is (back to) much more convenient.
 
 #### Other changes
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+// DEPPRECATED: _ will be removed soon
 var { Union, Result, Ok, Err, Maybe, Some, None, _ } = require('./index');
 
 
@@ -31,10 +32,15 @@ describe('Union', () => {
       const U = Union({A: 0, B: 0});
       assert.throws(() => U.match(U.A(), {a: () => 'whatever'}), Error);
     });
-    it('should always be exhaustive with a wildcard match', () => {
+    it('should always be exhaustive with a wildcard symbol match (DEPRECATED)', () => {
       const U = Union({A: 0, B: 0});
       assert.equal(U.match(U.A(), {[_]: () => 42}), 42);
       assert.equal(U.match(U.B(), {[_]: () => 42}), 42);
+    });
+    it('should allow literal _ as a key (not just the imported symbol)', () => {
+      const U = Union({A: 0, B: 0});
+      assert.equal(U.match(U.A(), {_: () => 42}), 42);
+      assert.equal(U.match(U.B(), {_: () => 42}), 42);
     });
     it('should pass a value to `match` callbacks', () => {
       const U = Union({A: 1});
@@ -54,13 +60,13 @@ describe('Union', () => {
       var f = () => null;
       assert.throws(() => U.match(U.A(), {A: f, B: f, C: f}), Error);
     });
-    it('should allow _ as a key (though this is a terrible idea)', () => {
+    it('should allow _ as a key (though this is a terrible idea) DEPRECATED', () => {
       const U = Union({
         A: null,
         _: null,
       });
       assert.equal(U.match(U.A(), {_: () => 0, A:   () => 1}), 1);
-      assert.equal(U.match(U.A(), {_: () => 0, [_]: () => 1}), 1);
+      // assert.equal(U.match(U.A(), {_: () => 0, [_]: () => 1}), 1);
       assert.equal(U.match(U._(), {_: () => 1, A:   () => 0}), 1);
       assert.equal(U.match(U._(), {_: () => 1, [_]: () => 0}), 1);
     });


### PR DESCRIPTION
Keeps the symbol _ around, deprecated, for one release.

implements #48 
