### PR TITLE
Expose options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+### v0.14.0
+
+2016-05-31
+
+### Breaking changes
+
+  * `options` is now a reserved key that can't be used as a union member.
+
+
 ### v0.13.0
 
 2016-03-23

--- a/index.es6
+++ b/index.es6
@@ -130,6 +130,9 @@ function Union(options, proto={}, static_={}, factory=_factory) {
   if (options.hasOwnProperty('match')) {
     throw new Error('Cannot use reserved name `match` as part of a Union');
   }
+  if (options.hasOwnProperty('options')) {
+    throw new UnionError('Cannot use reserved name `options` as part of a Union');
+  }
   if (options.hasOwnProperty('OptionClass')) {
     throw new Error('Cannot use reserved name `UnionClass` as part of a Union');
   }
@@ -154,6 +157,7 @@ function Union(options, proto={}, static_={}, factory=_factory) {
   UnionOption.unionFactory = Union;
 
   const union = {
+    options: options,
     OptionClass: UnionOption,
     toString: () => `[Union { ${Object.keys(options).join(', ')} }]`,
     match,

--- a/index.js
+++ b/index.js
@@ -160,6 +160,9 @@ function Union(options) {
   if (options.hasOwnProperty('match')) {
     throw new Error('Cannot use reserved name `match` as part of a Union');
   }
+  if (options.hasOwnProperty('options')) {
+    throw new UnionError('Cannot use reserved name `options` as part of a Union');
+  }
   if (options.hasOwnProperty('OptionClass')) {
     throw new Error('Cannot use reserved name `UnionClass` as part of a Union');
   }
@@ -207,6 +210,7 @@ function Union(options) {
   UnionOption.unionFactory = Union;
 
   var union = _extends({
+    options: options,
     OptionClass: UnionOption,
     toString: function toString() {
       return '[Union { ' + Object.keys(options).join(', ') + ' }]';

--- a/readme.md
+++ b/readme.md
@@ -290,11 +290,18 @@ Stoplight.match(Stoplight.Green(), {
 ```
 
 
+#### `options` static property on `union` object
+
+After creating a `union` object, the `.options` property references an object
+containing keys for each union option specified. It's not usually that useful
+unless you want to introspect the union and see what options it has -- powerful,
+but usually not necessary!
+
+
 ### `OptionClass()` constructor
 
 A function for creating OptionClass instances. You should not call this
-constructor directly, but rather use one of the factories attached to the
-`union` object via keys named after the union's members.
+constructor directly -- it's exposed just for `instanceof` checks.
 
 In the `Stoplight` example above, the following is ok:
 

--- a/test.js
+++ b/test.js
@@ -124,6 +124,19 @@ describe('Union', () => {
       }
     });
   });
+  describe('.options', () => {
+    it('should be exposed', () => {
+      const U = Union({A: null});
+      assert.deepEqual(U.options, {A: null});
+    });
+    it('should have all the options', () => {
+      const U = Union({A: null, B: null, C: null});
+      assert.deepEqual(U.options, {A: null, B: null, C: null});
+    });
+    it('should throw if constructed with `options` as an option', () => {
+      assert.throws(() => Union({options: null}));
+    });
+  });
   describe('errors thrown by results', () => {
     it('should be instance of Error', () => {
       assert.throws(() => Union());  // no members


### PR DESCRIPTION
fixes #89 

Exposes a `.options` object on the union option to find out which members the union has.
