### PR TITLE
Implement Maybe.prototype.filter

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -230,6 +230,9 @@ const maybeProto = {
   orElse(fn) {
     return (this.name === 'Some') ? this : Maybe.Some(fn());
   },
+  filter(fn) {
+    return this.andThen(x => fn(x) ? this : Maybe.None());
+  }
 };
 
 

--- a/readme.md
+++ b/readme.md
@@ -497,6 +497,23 @@ Since `andThen`'s callback is only executed if it's `Some()` and `orElse` if
 it's `None`, these two methods can be used like `.then` and `.catch` from
 Promise to chain data-processing tasks.
 
+#### `filter(fn)`
+
+Test a condition against the payload of a `Some(payload)`. If `fn` returns
+something false-y, `None` is returned. Otherwise, the same `Some(payload)` is
+returned.
+
+- **`fn`** If called on `Some`, `fn` is called with the payload as a param.
+
+```js
+import { Maybe } from 'results';
+
+const isEven = x => x % 2 === 0;
+
+Maybe.Some(42).filter(isEven);  // Some(42)
+Maybe.Some(41).filter(isEven);  // None()
+```
+
 ### `Result` -- `[Union { Ok, Err }]`
 
 An error-handling type.

--- a/test.js
+++ b/test.js
@@ -263,6 +263,11 @@ describe('Maybe', () => {
     assert.ok(None().orElse(() => 1).isSome());
     assert.equal(None().orElse(() => 1).unwrap(), 1);
   });
+  it('.filter should none-ify false-y returns', () => {
+    assert.ok(None().filter(x => true).isNone());
+    assert.equal(Some(1).filter(x => true).unwrap(), 1);
+    assert.ok(Some(1).filter(x => false).isNone());
+  });
   it('.equals should work', () => {
     assert.ok(None().equals(None()));
     assert.ifError(None().equals(Some()));


### PR DESCRIPTION
Like Array.prototype.filter, given a test function, a passing Some(value) can
pass through or be turned into a None() if `test(value)` is false-y.

I really wonder if there is a reason besides lack of motivation that other
option types don't seem to implement this method. It has come up quite
frequently on code I've worked with.