### PR TITLE
Throw `new Error(msg)` for expect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 Changes
 =======
 
+### v0.15.0
+
+#### Breaking changes
+
+  * .expect(msg) for both `Maybe` and `Result` now wrap their payload in `new
+    Error()` instead of just throwing the payload directly.
+
+
 ### v0.14.1
 
 2016-12-08

--- a/index.es6
+++ b/index.es6
@@ -181,13 +181,13 @@ const maybeProto = {
     return this.name === 'None';
   },
   /**
-   * @throws whatever is passed as the arg
+   * @throws Error(msg)
    */
-  expect(err) {
+  expect(msg) {
     if (this.name === 'Some') {
       return this.payload;
     } else {
-      throw err;
+      throw new Error(msg);
     }
   },
   /**
@@ -303,13 +303,13 @@ const resultProto = {
     return (this.name === 'Ok') ? this.payload : fn(this.payload);
   },
   /**
-   * @throws err
+   * @throws Error(err)
    */
   expect(err) {
     if (this.name === 'Ok') {
       return this.payload;
     } else {
-      throw err;
+      throw new Error(err);
     }
   },
   /**

--- a/readme.md
+++ b/readme.md
@@ -404,18 +404,18 @@ assert(!None().isSome() && None().isNone());
 
 Get the payload of a `Some()`, **or throw if it's `None()`**.
 
-##### `expect(err)`
+##### `expect(msg)`
 
-Like `unwrap()`, but throws a custom error if it is `None()`.
+Like `unwrap()`, but throws an Error(msg) if it is `None()`.
 
-- **`err`** The error to throw if it is `None()`
+- **`msg`** The message to throw with if it is `None()`
 
 ```js
 import { Some, None } from 'results';
 const n = Some(1).unwrap();  // n === 1
 const m = None().unwrap();  // throws an Error instance
-const o = Some(1).expect('err')  // o === 1
-const p = None().expect('err')  // throws 'err'
+const o = Some(1).expect('msg')  // o === 1
+const p = None().expect('msg')  // throws Error('msg')
 ```
 
 ##### `unwrapOr(def)`
@@ -567,7 +567,7 @@ assert(!Err(2).isOk() && Err(2).isErr());
 
 ##### `expect(err)`
 
-Returns the payload from an `Ok(payload)`, or throws `err`.
+Returns the payload from an `Ok(payload)`, or throws `Error(err)`.
 
 
 ##### `unwrap()`

--- a/test.js
+++ b/test.js
@@ -176,7 +176,13 @@ describe('Maybe', () => {
   });
   it('should throw or not for expect', () => {
     assert.doesNotThrow(() => {Some(1).expect('err')});
-    assert.throws(() => {None().expect('err')}, 'err');
+    assert.throws(() => {None().expect('err')}, Error);
+    try {
+      None().expect('hello 123');
+      assert.fail('Should have thrown');
+    } catch (err) {
+      assert.equal(err.message, 'hello 123');
+    }
   });
   it('should unwrap or throw', () => {
     assert.equal(Some(1).unwrap(), 1);
@@ -404,7 +410,13 @@ describe('Result', () => {
   });
   it('.expect', () => {
     assert.equal(Ok(1).expect(), 1);
-    assert.throws(() => Err(1).expect(new Error('asdf')), Error);
+    assert.throws(() => Err(1).expect('asdf'), Error);
+    try {
+      Err('fdsa').expect('hello 123');
+      assert.fail('Should have thrown');
+    } catch (err) {
+      assert.equal(err.message, 'hello 123');
+    }
   });
   it('.and', () => {
     assert.ok(Ok(1).and(Ok(-1)).isOk());


### PR DESCRIPTION
...instead of just throwing the payload directly. This improves twot things:

1. It's nicer to use. `myThing.expect('should have blah')` instead of
   `myThing.expect(new Error('should have blah'))`.

2. It saves overhead. Putting `new Error(message)` always creates the error,
   including generating the stacktrace and everything. Boo. I haven't actually
   measured it, but if that was hurting before, it shouldn't any more.